### PR TITLE
Fix Updated entries for GitHub repos

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,3 +13,4 @@ For a full contributor list, see <https://github.com/open-energy-transition/open
 - Bryn Pickering, Open Energy Transition <bryn.pickering@openenergytransition.org>
 - Markus Groissböck, Open Energy Transition <markus.groissbock@openenergytransition.org>
 - Jacek Bendig, Open Energy Transition <jacek.bendig@openenergytransition.org>
+- Ruaridh Macdonald, <ruaridh.macd@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2025-10-06
+
+- Fixed: a bug in the "Updated" field. It now correctly reports the date-time of the most recent change to a tool's repository. However, this change can be a push to any branch, not just the main or published branch.
+
 ## 2025-09-23
 
 ### Added

--- a/inventory/get_stats.py
+++ b/inventory/get_stats.py
@@ -26,6 +26,7 @@ ENTRIES_TO_KEEP = [
     "license",
     "created_at",
     "pushed_at",
+    "updated_at",
     "commit_stats.dds",
     "commit_stats.total_committers",
     "homepage",

--- a/inventory/get_stats.py
+++ b/inventory/get_stats.py
@@ -25,7 +25,7 @@ ENTRIES_TO_KEEP = [
     "language",
     "license",
     "created_at",
-    "updated_at",
+    "pushed_at",
     "commit_stats.dds",
     "commit_stats.total_committers",
     "homepage",

--- a/website/⚡️_Tool_Repository_Metrics.py
+++ b/website/⚡️_Tool_Repository_Metrics.py
@@ -26,7 +26,7 @@ OET_LOGO_ABBREVIATED = "https://raw.githubusercontent.com/open-energy-transition
 
 COLUMN_NAME_MAPPING: dict[str, str] = {
     "created_at": "Created",
-    "updated_at": "Updated",
+    "pushed_at": "Updated",
     "stargazers_count": "Stars",
     "commit_stats.total_committers": "Contributors",
     "commit_stats.dds": "DDS",
@@ -39,7 +39,7 @@ COLUMN_NAME_MAPPING: dict[str, str] = {
 
 COLUMN_DTYPES: dict[str, Callable] = {
     "created_at": pd.to_datetime,
-    "updated_at": pd.to_datetime,
+    "pushed_at": pd.to_datetime,
     "stargazers_count": pd.to_numeric,
     "commit_stats.total_committers": pd.to_numeric,
     "commit_stats.dds": lambda x: 100 * pd.to_numeric(x),

--- a/website/⚡️_Tool_Repository_Metrics.py
+++ b/website/⚡️_Tool_Repository_Metrics.py
@@ -40,6 +40,7 @@ COLUMN_NAME_MAPPING: dict[str, str] = {
 COLUMN_DTYPES: dict[str, Callable] = {
     "created_at": pd.to_datetime,
     "pushed_at": pd.to_datetime,
+    "updated_at": pd.to_datetime,
     "stargazers_count": pd.to_numeric,
     "commit_stats.total_committers": pd.to_numeric,
     "commit_stats.dds": lambda x: 100 * pd.to_numeric(x),
@@ -122,6 +123,9 @@ def create_vis_table(tool_stats_dir: Path, user_stats_dir: Path) -> pd.DataFrame
     df["Score"] = pd.Series(
         np.random.choice([0, 100], size=len(df.index)), index=df.index
     )
+    # Fill empty dates in "pushed_at" with equivalent entries from "updated_at"
+    df["pushed_at"] = df["pushed_at"].fillna(df["updated_at"])
+
     df_vis = df.rename(columns=COLUMN_NAME_MAPPING)[
         EXTRA_COLUMNS + list(COLUMN_NAME_MAPPING.values())
     ]


### PR DESCRIPTION
Fixes #116 

This addresses issues #116 , where the "Updated" date was incorrect for tools hosted on GitHub. 

As discussed with @brynpickering, the solution was to use the `pushed_at` rather. than `updated_at` field from ecosyste.ms. This correctly reports the most recent commit, though its to any branch on the repo or its wiki. 

One issue was that the `pushed_at` fields has a `NaT` (not a time) value for non-GitHub repos. Most tools are hosted on GitHub so I decided to have the "Updated" column on the tracker be first populated from `pushed_at` and then any NaN/NaT values filled with `updated_at`. This relies on everyone repo having a valid time `updated_at` entry, so it's not a perfect solution.

The pixi workflows all run locally for me. I went through quite a few tools and the "Updated" date time appears to be correct for the ones hosted on GitLab and GitHub. Alternatives, such as BitBucket, were harder to verify but appear to be correct. 

## Summary of changes in this pull request

- A bug in the "Updated" field has been fixed. It now correctly reports the date-time of the most recent change to a tool's repository, though this can be a push to any branch, not just the main or published branch.

## Contributor checklist

- [x] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- [x] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Changelog updated
