### PR TITLE
Fix the pypi logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Calendar Versioning](https://calver.org/).
 
+## 2026-08-31
+
+### Fixed
+- Failing PyPI logo.
+
 ## 2026-07-31
 
 ### Fixed

--- a/website/pages/4_📦_Deep_Dive_-_Download_Trends.py
+++ b/website/pages/4_📦_Deep_Dive_-_Download_Trends.py
@@ -502,7 +502,7 @@ def show_all_packages_list(
                 if pd.notna(pypi_url):
                     links_html += (
                         f'<a href="{pypi_url}" target="_blank" style="text-decoration:none; color:inherit; margin-right:12px;">'
-                        f'<img src="https://pypi.org/static/images/logo-small.8998e9d1.svg" width="13" '
+                        f'<img src="https://pypi.org/static/images/logo-small.0e0855d0.svg" width="13" '
                         f'style="vertical-align:middle; margin-right:4px;">'
                         f"PyPI</a>"
                     )


### PR DESCRIPTION
The PyPI logo in the deep dive page 4_📦_Deep_Dive_-_Download_Trends.py was not showing anymore. I have replaced it.

## Contributor checklist

- [x] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- [x] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [x] Changelog updated
