### PR TITLE
Fix graphql commit hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Calendar Versioning](https://calver.org/).
 ## 2026-08-31
 
 ### Fixed
+
+- GitHub commit history pagination cache, which was storing cursors containing the branch head SHA and so went stale as soon as new commits were pushed (#243).
+  Only the item index is now cached and the cursor is rebuilt from the current head SHA on each run.
 - Failing PyPI logo.
 - Fix failing CI
 

--- a/user_analysis/config/pagination_cache_gh.yaml
+++ b/user_analysis/config/pagination_cache_gh.yaml
@@ -1,365 +1,664 @@
-adamgreenhall.minpower.commits: 955c137b38a0cfcfedf61b812755c257d396ec83 799
-adgefficiency.energy-py-linear.commits: 34dd5df3843447b02d52847379c79299d3a05141 99
+adamgreenhall.minpower.commits:
+  offset: 799
+  total: 886
+adgefficiency.energy-py-linear.commits:
+  offset: 99
+  total: 169
 adgefficiency.energy-py.stargazers: Y3Vyc29yOnYyOpK0MjAxOS0wOC0xOFQyMzozMDowOFrOCuY94Q==
-ahalev.python-microgrid.commits: 09089ccfaab3e95becfda1b26fbce6f9c6195f6a 1799
+ahalev.python-microgrid.commits:
+  offset: 1799
+  total: 1883
 ahalev.python-microgrid.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMy0xMlQxNjoyMTo0M1rOJ9tudA==
-ait-energy.iesopt.jl.commits: 54c36a51dc8d57e686ecfeaec42abf8114f20819 499
+ait-energy.iesopt.jl.commits:
+  offset: 499
+  total: 563
 ait-energy.iesopt.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0xMlQwMDo1NDoxMlrO2nqcAQ==
-akkudoktor-eos.eos.commits: 47ffa0fa1ab3443c9d593292870cf1f3a9cac09e 899
+akkudoktor-eos.eos.commits:
+  offset: 899
+  total: 932
 akkudoktor-eos.eos.forks: Y3Vyc29yOnYyOpHOPTeAXw==
 akkudoktor-eos.eos.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMi0yNFQxODo1MTo1N1rO7YrSlw==
 akkudoktor-eos.eos.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0yNlQwNDozMDoyN1rO30Oj0w==
 akkudoktor-eos.eos.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMS0yNlQwOTo0MDo1MVrOJv2dvw==
-andrewlyden.pylesa.commits: 0691d63c8d8c1f920c206c1bfb04582a35031fd5 99
-anl-ceeesa.stream.commits: b931e95f134ad0bd52a9886a2cbb6d87b8c9f35a 99
-anl-ceeesa.unitcommitment.jl.commits: cfc1484e158cfcc97a767dcbf9eccb8f60e83464 399
+andrewlyden.pylesa.commits:
+  offset: 99
+  total: 162
+anl-ceeesa.stream.commits:
+  offset: 99
+  total: 134
+anl-ceeesa.unitcommitment.jl.commits:
+  offset: 399
+  total: 493
 anl-ceeesa.unitcommitment.jl.stargazers: Y3Vyc29yOnYyOpK0MjAyNC0wOC0wNlQyMzoyOToxOVrOHyN3Og==
-antaressimulatorteam.antares_simulator.commits: aa2c0bbfe919475d5b4944b0a3f04a51d7f7092c
-  2799
+antaressimulatorteam.antares_simulator.commits:
+  offset: 2799
+  total: 2848
 antaressimulatorteam.antares_simulator.issues: Y3Vyc29yOnYyOpK0MjAyMy0xMi0xOFQwOTo1Njo0MVrOefbc9g==
 antaressimulatorteam.antares_simulator.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNy0xNVQwODo1NzowMlrO8fEFsQ==
-arfc.osier.commits: ba0b66eaf8177ff490db40d3426069b12310fc8e 399
+arfc.osier.commits:
+  offset: 399
+  total: 485
 arras-energy.gridlabd.issues: Y3Vyc29yOnYyOpK0MjAyNC0wNi0wM1QxOTo0NDoxOFrOiv4VzQ==
 arras-energy.gridlabd.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wNy0wNlQxNzo1NTo0MlrOnaWsmw==
-arthurrinaldi.grimsel.commits: 60db953b52241405ee1795321c6a6fecf09ebf55 899
-assume-framework.assume.commits: c330ab53f94cb2f247d329b66aa450b64c2b2d0a 1499
+arthurrinaldi.grimsel.commits:
+  offset: 899
+  total: 946
+assume-framework.assume.commits:
+  offset: 1499
+  total: 1555
 assume-framework.assume.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMi0yNFQxNzowMTozOVrO7YNSTA==
 assume-framework.assume.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNy0xM1QxOToyOTozNVrO8TtcOA==
-balmorelcommunity.balmorel.commits: e6f416855a5cd956428929d8eaa27b77dcc3646e 499
-behrangshirizadeh.eoles_elecres.commits: 6e05a549138a94f5b3a27a7e6704b1c92afa4a8a
-  99
-bje-.nemo.commits: da3ab7fa57030f413044a16e66cf6dc37ed5b9e8 1699
-blue-marble.gridpath.commits: 1ae84ae70a916a483e9c618ae62e622ebb773ac5 1599
+balmorelcommunity.balmorel.commits:
+  offset: 499
+  total: 517
+behrangshirizadeh.eoles_elecres.commits:
+  offset: 99
+  total: 111
+bje-.nemo.commits:
+  offset: 1699
+  total: 1771
+blue-marble.gridpath.commits:
+  offset: 1599
+  total: 1683
 blue-marble.gridpath.issues: Y3Vyc29yOnYyOpK0MjAyMi0xMi0xNlQxODo0NDoyN1rOWXLVuA==
 blue-marble.gridpath.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0yM1QxODozOTowMFrO1RUpgQ==
 blue-marble.gridpath.stargazers: Y3Vyc29yOnYyOpK0MjAyNC0xMi0yN1QxMTo1MTo1N1rOIRrsWA==
-breakthrough-energy.reise.jl.commits: 8b2a4770fdc69ec723d2bbe102c3a96677702763 399
+breakthrough-energy.reise.jl.commits:
+  offset: 399
+  total: 410
 breakthrough-energy.reise.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyMS0wNi0yNVQxNTo0MDowNlrOKGmbQw==
-calliope-project.calliope.commits: f0c6ac47016fab0ad2b9769558d120881108f558 1299
+calliope-project.calliope.commits:
+  offset: 1299
+  total: 1319
 calliope-project.calliope.forks: Y3Vyc29yOnYyOpHOQSQ9tQ==
 calliope-project.calliope.issues: Y3Vyc29yOnYyOpK0MjAyNS0wOS0xOFQwODozNzozNVrOzGdH1Q==
 calliope-project.calliope.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wOS0wNFQxMDo1MjozN1rOptQ6Tw==
 calliope-project.calliope.stargazers: Y3Vyc29yOnYyOpK0MjAyNC0xMS0yMVQwOTozODo0NVrOIJmwYA==
-cea-liten.cairnopen.commits: 8bca98c1f01390520d06b0602d1043d9bf1064d7 99
-changgang.steps.commits: 4f380e8de9ba2ecd8fb59ed3e072001484923c3b 699
-chengts95.rustpower.commits: de8fcdd8760a4e741602069f244cb3e945f723fa 99
-critical-infrastructure-systems-lab.pownet.commits: 08fd18d58f214edbbf5219bb2070451ba627921f
-  699
-csenkpiel.inve2st.commits: aaee81cf9eefefe89eb7f1fee624063bd56141ac 499
-curent.andes.commits: eda5163c9ee8d19945a1dd5d1771fec5da608c27 4799
+cea-liten.cairnopen.commits:
+  offset: 99
+  total: 103
+changgang.steps.commits:
+  offset: 699
+  total: 799
+chengts95.rustpower.commits:
+  offset: 99
+  total: 174
+critical-infrastructure-systems-lab.pownet.commits:
+  offset: 699
+  total: 719
+csenkpiel.inve2st.commits:
+  offset: 499
+  total: 525
+curent.andes.commits:
+  offset: 4799
+  total: 4810
 curent.andes.forks: Y3Vyc29yOnYyOpHON7xJzw==
 curent.andes.pullRequests: Y3Vyc29yOnYyOpK0MjAyMi0wNC0yM1QxNzoyNTo0NVrONqwNbg==
 curent.andes.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0xMC0zMVQxMzoyMDoxNlrOJalE-g==
-derrickoswald.cimapplication.commits: 3c12a0f66a7ba0d3ddc7d224fe981ec9baaaafa9 1999
-drafproject.draf.commits: 949c3d22836d4df01ec582c37034ef5bfc920f23 99
-dss-extensions.dss_capi.commits: f5728aec36becd20c19ad2dfc98fa8cf181f8835 2399
+derrickoswald.cimapplication.commits:
+  offset: 1999
+  total: 2032
+drafproject.draf.commits:
+  offset: 99
+  total: 191
+dss-extensions.dss_capi.commits:
+  offset: 2399
+  total: 2411
 dss-extensions.dss_capi.issues: Y3Vyc29yOnYyOpK0MjAyMi0wNy0yMVQxODozNTowM1rOTky0cQ==
-dynawo.dynawo.commits: c0d4f9a66523f42f8e7181a7298337555f94661b 2599
+dynawo.dynawo.commits:
+  offset: 2599
+  total: 2696
 dynawo.dynawo.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMi0wNVQxNTozMDowMlrO6JZmGw==
 dynawo.dynawo.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNi0yOVQxNTo1MDoxMlrO69qmqA==
 dynawo.dynawo.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMy0wMVQyMDoyMDoyOFrOJ5rZVw==
-e2niee.pandapower.commits: 265eaf365b9af55ff37a2abbf754fc1c316dac11 10699
+e2niee.pandapower.commits:
+  offset: 10699
+  total: 10753
 e2niee.pandapower.forks: Y3Vyc29yOnYyOpHOP15slA==
 e2niee.pandapower.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMy0yN1QwNjo0OTo0N1rO91u5GA==
 e2niee.pandapower.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0yMlQxNzoyMToxOFrO1LVKng==
 e2niee.pandapower.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMi0yMFQxNzowMTozNFrOJ27UgA==
-e3-.resolve.commits: 0cad0c79dc0d0a21673515705e2d6e9a8cd8e541 99
-e4st-dev.e4st.jl.commits: 49c5070a1d58103cbbba33a5aab6d103eb884ad8 1099
+e3-.resolve.commits:
+  offset: 99
+  total: 103
+e4st-dev.e4st.jl.commits:
+  offset: 1099
+  total: 1130
 e4st-dev.e4st.jl.issues: Y3Vyc29yOnYyOpK0MjAyMy0wNy0xOFQxNzo1OToyNFrOa-kWJQ==
 e4st-dev.e4st.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyMy0wOS0yOFQxODo1Njo0OFrOW3mvRA==
-electa-git.flexplan.jl.commits: b64fd6f8f14294d5b43c4d6029198ae54b8bfaed 699
+electa-git.flexplan.jl.commits:
+  offset: 699
+  total: 769
 electa-git.flexplan.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyMi0wMi0yM1QwNzoyODowMVrOM1OgeA==
-eliagroup.toop.commits: e8b38ee67a75102151b9bf8cb75a9f33fef1ce77 99
+eliagroup.toop.commits:
+  offset: 99
+  total: 199
 eliagroup.toop.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNi0xMFQwNzo1MzozMlrO5L5WtA==
-emlab.emlab-generation.commits: 591488984ece6992fab60dd1304e91a8496035f7 199
-energy-modelling-toolkit.dispa-set.commits: b30cc1a4a16b51ef2a1b33b1647647766180864f
-  899
-energyinnovation.eps-us.commits: aa248553ef9904becf4f06bb41ac8c7d69cad4e1 2899
+emlab.emlab-generation.commits:
+  offset: 199
+  total: 278
+energy-modelling-toolkit.dispa-set.commits:
+  offset: 899
+  total: 993
+energyinnovation.eps-us.commits:
+  offset: 2899
+  total: 2910
 energyinnovation.eps-us.issues: Y3Vyc29yOnYyOpK0MjAyNi0wNi0wM1QxMzo1MjowNFrPAAAAAREEe-0=
-energymodelsx.energymodelsbase.jl.commits: fe585fff7e800b7b9a0a3da706361b817f48e6bb
-  199
-energysystemsmodellinglab.muse2.commits: 44f33be76cefa29ebbe99c1576eea8255cfd76e5
-  3799
+energymodelsx.energymodelsbase.jl.commits:
+  offset: 199
+  total: 238
+energysystemsmodellinglab.muse2.commits:
+  offset: 3799
+  total: 3869
 energysystemsmodellinglab.muse2.issues: Y3Vyc29yOnYyOpK0MjAyNi0wNi0xMlQxNDoyNToyMFrPAAAAARUpv2o=
 energysystemsmodellinglab.muse2.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNi0wMVQwMDo1MjowNVrO4S8F7w==
-energysystemsmodellinglab.muse_os.commits: bc1454f4140b5427ff183f5357d909c7d0125a04
-  2899
+energysystemsmodellinglab.muse_os.commits:
+  offset: 2899
+  total: 2958
 energysystemsmodellinglab.muse_os.issues: Y3Vyc29yOnYyOpK0MjAyNS0wNy0xNVQxMzo0ODoxOVrOwKmgYw==
 energysystemsmodellinglab.muse_os.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0xM1QxMzo0OTo0OFrO0f-DNg==
-epri-dev.opender.commits: fe7877c664bc6c5eb3832499bf05e0f1dd1825c8 99
-erf-model.erf.commits: 26cd0b2d40aa8bc9c96f14c97f75d11a20ef1d86 4699
+epri-dev.opender.commits:
+  offset: 99
+  total: 125
+erf-model.erf.commits:
+  offset: 4699
+  total: 4725
 erf-model.erf.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMy0xNlQxMzowOTo1NlrO81R6hQ==
 erf-model.erf.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNy0xNVQwNDo0NTo0N1rO8dzTAg==
-esdlmapeditoressim.essim.commits: 13da4a91cba0ff5122f0ed0599fda087427404e8 99
-esmap-world-bank-group.epm.commits: b0b979227508c1e37c9466675ebdadece0d786f4 2499
+esdlmapeditoressim.essim.commits:
+  offset: 99
+  total: 124
+esmap-world-bank-group.epm.commits:
+  offset: 2499
+  total: 2583
 etsap-times.times_model.stargazers: Y3Vyc29yOnYyOpK0MjAyNC0wOS0wM1QxNDoyNTo1MVrOH4XbXw==
-fbumann.fluxopt.commits: 5046e466260b7c85070a355d8d504a13303d8736 99
+fbumann.fluxopt.commits:
+  offset: 99
+  total: 124
 fbumann.fluxopt.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0yOFQxNDoyOTo1M1rO1l-FbQ==
-flexiblepower.powermatcher.commits: 7ac5a4049787dd5d4f1fc4fe577d31048cdf19ba 699
+flexiblepower.powermatcher.commits:
+  offset: 699
+  total: 722
 flexiblepower.powermatcher.issues: Y3Vyc29yOnYyOpK0MjAxNC0xMi0wMlQxMDozMzoyN1rOAwSgnA==
-flexigis.flexigis.commits: e6c4be6747f0e17846917a3576aa347dfb991b9b 99
-flixopt.flixopt.commits: 8ddd46979e7bee8e8de39df6e60a3d88edf935b6 2399
+flexigis.flexigis.commits:
+  offset: 99
+  total: 134
+flixopt.flixopt.commits:
+  offset: 2399
+  total: 2443
 flixopt.flixopt.issues: Y3Vyc29yOnYyOpK0MjAyNS0wOS0xMlQyMjowNzowNlrOy1_JKQ==
 flixopt.flixopt.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0wNVQxMjo0MzoxMFrO0AraDQ==
-fluxopt.fluxopt.commits: 4320efe56fe5fe61f49c6f6739beab95015d8d5a 99
+fluxopt.fluxopt.commits:
+  offset: 99
+  total: 143
 fluxopt.fluxopt.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0yOFQxNDoyOTo1M1rO1l-FbQ==
-future-power-networks.simplus-grid-tool.commits: b0abbcc0e48f8c6d472c1bbcb88d7eadb49b22f2
-  299
+future-power-networks.simplus-grid-tool.commits:
+  offset: 299
+  total: 312
 future-power-networks.simplus-grid-tool.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0xMi0xMFQwNjoxNjozNFrOJj7cTw==
-fzj-iek3-vsa.fine.commits: 4ffd5e3ccfcaf898f534d1bf0053a64f8412c06e 2199
+fzj-iek3-vsa.fine.commits:
+  offset: 2199
+  total: 2281
 fzj-iek3-vsa.fine.issues: Y3Vyc29yOnYyOpK0MjAyNi0wNi0yM1QxMDowNjo0NlrPAAAAARmeG5g=
 fzj-iek3-vsa.fine.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0yOFQxMjo0NzozOFrO4Dxodg==
-genesys-mod.genesys_mod.gms.commits: 0185cc1f5a32c74d10383f395439503b1698227f 199
-genesys-mod.genesysmod.jl.commits: bb2be8f5caa765f8eb6ba11929eb7cce7a8d8b4d 99
-genxproject.genx.jl.commits: 3d9596ad9ce69e66ed0404754e58250059bf612b 1099
+genesys-mod.genesys_mod.gms.commits:
+  offset: 199
+  total: 212
+genesys-mod.genesysmod.jl.commits:
+  offset: 99
+  total: 189
+genxproject.genx.jl.commits:
+  offset: 1099
+  total: 1135
 genxproject.genx.jl.forks: Y3Vyc29yOnYyOpHOMOA7VQ==
 genxproject.genx.jl.issues: Y3Vyc29yOnYyOpK0MjAyNS0wNC0yOFQyMjowNzoyOVrOtGKFEQ==
 genxproject.genx.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNC0wOS0yM1QyMTo1NjowMlrOfG51lw==
 genxproject.genx.jl.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0wNC0xOVQxNjo0OTowMVrOItU-gQ==
-gmlc-dispatches.dispatches.commits: a9e9b7a7d132f53cd47d63e62c8b0a8722e7fd37 399
+gmlc-dispatches.dispatches.commits:
+  offset: 399
+  total: 459
 gmlc-dispatches.dispatches.pullRequests: Y3Vyc29yOnYyOpK0MjAyMi0wOC0yMlQyMzozMzoxMlrOPZl2dQ==
-grid-parity-exchange.egret.commits: 3722e29d2b613cb708788cc9b64a0b034596bbe9 1099
+grid-parity-exchange.egret.commits:
+  offset: 1099
+  total: 1103
 grid-parity-exchange.egret.pullRequests: Y3Vyc29yOnYyOpK0MjAyMi0wNC0wNVQxOTo0ODo0N1rONa706Q==
 grid-parity-exchange.egret.stargazers: Y3Vyc29yOnYyOpK0MjAyMy0wMi0yN1QxNDo0NzoyMVrOF1NZNw==
-grid2op.chronix2grid.commits: 745c3b38b9d69dc702fbca4e80706fd803a047be 599
-grid2op.grid2op.commits: d74b8e11a238ebea40fd17694529347bb4854d3c 3499
+grid2op.chronix2grid.commits:
+  offset: 599
+  total: 683
+grid2op.grid2op.commits:
+  offset: 3499
+  total: 3571
 grid2op.grid2op.forks: Y3Vyc29yOnYyOpHOLwR0Gg==
 grid2op.grid2op.issues: Y3Vyc29yOnYyOpK0MjAyMy0wOS0yOFQyMTowNDozNlrOclaB3g==
 grid2op.grid2op.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wMi0yNVQyMDo0NzoxOVrOjIgNKQ==
 grid2op.grid2op.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMS0yMFQwNTowNjo0M1rOJuDr8A==
-gridfm.gridfm-graphkit.commits: acbf7be5dc7edac4d2dd22df39108a60c58659a5 299
-gridoptics.gridpack.commits: bb411473c48d0e17aecfe52703546f72bb5bd00d 3299
+gridfm.gridfm-graphkit.commits:
+  offset: 299
+  total: 387
+gridoptics.gridpack.commits:
+  offset: 3299
+  total: 3317
 gridoptics.gridpack.issues: Y3Vyc29yOnYyOpK0MjAyMy0wMy0xNlQxNDowNzozOFrOYQK__Q==
 gridoptics.gridpack.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wNi0wNFQxNzozNjozNlrOmRClqw==
-hope-model-project.hope.commits: f332ab27f514965245971d18ce4737050f0e59f8 399
-idaholab.heron.commits: 6037659d98153d91e49b2ad2b9806dc9b7dcdda2 799
+hope-model-project.hope.commits:
+  offset: 399
+  total: 463
+idaholab.heron.commits:
+  offset: 799
+  total: 845
 idaholab.heron.issues: Y3Vyc29yOnYyOpK0MjAyNS0wNi0wNFQxODowNTozOFrOueLtKg==
 idaholab.heron.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wOS0yM1QxODoxNjowNVrOqh9CSQ==
-idaholab.hybrid.commits: d32621a05559d06ee3799495bce6085df0fadfc2 299
-ie3-institute.powersystemdatamodel.commits: 0da0dbe9cec379b1e2ed9ebeec518a79bb71e24a
-  5899
+idaholab.hybrid.commits:
+  offset: 299
+  total: 347
+ie3-institute.powersystemdatamodel.commits:
+  offset: 5899
+  total: 5919
 ie3-institute.powersystemdatamodel.issues: Y3Vyc29yOnYyOpK0MjAyNi0wNC0xNFQxNjo0MDowN1rO_h_5SA==
 ie3-institute.powersystemdatamodel.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0xM1QwNDowMzoxMFrO0dybYQ==
-ie3-institute.simona.commits: ed2a58feb95cd3e4cb0b4db4cdc8b7c0814e7213 7399
+ie3-institute.simona.commits:
+  offset: 7399
+  total: 7471
 ie3-institute.simona.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMi0wMlQxNjo0MDoxOFrO56232Q==
 ie3-institute.simona.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wMy0yNVQxNzoyMzo0M1rOzW1DKw==
-iiasa.message_ix.commits: b0ded639dc0ef04c902b4d96b571e6f276848207 1999
+iiasa.message_ix.commits:
+  offset: 1999
+  total: 2006
 iiasa.message_ix.forks: Y3Vyc29yOnYyOpHOGpBKOA==
 iiasa.message_ix.issues: Y3Vyc29yOnYyOpK0MjAyNC0wMS0xMlQwNjo1Nzo0NFrOe96ypg==
 iiasa.message_ix.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wNi0wM1QwODo1OToxNVrOmMb-0g==
 iiasa.message_ix.stargazers: Y3Vyc29yOnYyOpK0MjAyMy0xMS0yOFQyMDozODoyMlrOG30qtA==
-iit-energysystemmodels.opensduc.commits: 3759b362acccc5fa785129940e02d6147b6099b7
-  99
-iit-energysystemmodels.opentepes.commits: 950a3cf104a2b92e791ee3e40bbbc043520706a4
-  3399
+iit-energysystemmodels.opensduc.commits:
+  offset: 99
+  total: 177
+iit-energysystemmodels.opentepes.commits:
+  offset: 3399
+  total: 3441
 iit-energysystemmodels.opentepes.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0wNVQxMjo0NTowNFrO2GUXiQ==
-ijbd.assetra.commits: 37a34e8e7c1c714b4945a7fc2525971abe15a5f3 199
-inwe-boku.medea.commits: 2abb2765fc2058308b46648f495295ac915385a8 199
-ipese.reho.commits: 1d65657ea6100c566226d67f43b77388056fe21d 599
-irena-flextool.flextool.commits: c89d7454be811448199221cfb52cc772f3342008 1099
+ijbd.assetra.commits:
+  offset: 199
+  total: 259
+inwe-boku.medea.commits:
+  offset: 199
+  total: 240
+ipese.reho.commits:
+  offset: 599
+  total: 604
+irena-flextool.flextool.commits:
+  offset: 1099
+  total: 1164
 irena-flextool.flextool.issues: Y3Vyc29yOnYyOpK0MjAyNS0xMC0wOVQwNzo0NToyNlrO0H-Qpw==
-juliaenergy.powerdynamics.jl.commits: 552ff5ebf3edda5f077ca6de14200ea02793ec67 1199
+juliaenergy.powerdynamics.jl.commits:
+  offset: 1199
+  total: 1261
 juliaenergy.powerdynamics.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0yNlQwMzo0OTo0MlrO1a25SA==
 juliaenergy.powerdynamics.jl.stargazers: Y3Vyc29yOnYyOpK0MjAyNC0wOC0wOFQyMTo1MDowNFrOHyra8A==
-kiedanski.pymarket.commits: 0d73fe45a2c458a02e660816369e4699decefb2b 199
-lanl-ansi.powermodels.jl.commits: f0d535816cc600ae86f0756a582de4909da4741c 999
+kiedanski.pymarket.commits:
+  offset: 199
+  total: 226
+lanl-ansi.powermodels.jl.commits:
+  offset: 999
+  total: 1023
 lanl-ansi.powermodels.jl.forks: Y3Vyc29yOnYyOpHOH0dbxA==
 lanl-ansi.powermodels.jl.issues: Y3Vyc29yOnYyOpK0MjAyNS0wNy0yM1QwOTo1NDo1NlrOwg42FA==
 lanl-ansi.powermodels.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyMi0wOC0wN1QwMzozNjo1N1rOPMO6YQ==
 lanl-ansi.powermodels.jl.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0wMS0wN1QxMjo1MDo1OVrOIUGRAg==
-lanl-ansi.powermodelsannex.jl.commits: f3f3fc83976d714962a45f6b90f10af8b05b5cc1 99
-leonardgoeke.anymod.jl.commits: dede89b9e9875d4a4c0abb3cd0ef401cc724c46a 399
-lkruitwagen.global-fossil-fuel-supply-chain.commits: 9bf994b34d4615f6490512680b646fe3d31d569e
-  99
+lanl-ansi.powermodelsannex.jl.commits:
+  offset: 99
+  total: 158
+leonardgoeke.anymod.jl.commits:
+  offset: 399
+  total: 428
+lkruitwagen.global-fossil-fuel-supply-chain.commits:
+  offset: 99
+  total: 103
 lkruitwagen.global-fossil-fuel-supply-chain.stargazers: Y3Vyc29yOnYyOpK0MjAyMi0wNy0wNFQwMDowNjo1OFrOFItI_Q==
-lukasbarner.hydrogenmod.jl.commits: d79ad0cbc350837489b50de5fe03ae6569edde04 99
-macroenergy.macroenergy.jl.commits: 9964947c6fc533529f1f9463c399824b3de6acb8 1699
+lukasbarner.hydrogenmod.jl.commits:
+  offset: 99
+  total: 104
+macroenergy.macroenergy.jl.commits:
+  offset: 1699
+  total: 1795
 macroenergy.macroenergy.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0xM1QyMjoxMToxMVrO201KmA==
-manuvarkey.gelectrical.commits: 47082c74b39f8075dbca9b643c64d069604bd22f 399
+manuvarkey.gelectrical.commits:
+  offset: 399
+  total: 433
 manuvarkey.gelectrical.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0xMi0wM1QxNTo0MDowOVrOJiaoFg==
-marvinler.pypownet.commits: 8839d90b11f0241844355594184156c42b1d1ef6 299
+marvinler.pypownet.commits:
+  offset: 299
+  total: 318
 marvinler.pypownet.stargazers: Y3Vyc29yOnYyOpK0MjAyMy0xMC0wNlQyMTozOTowNFrOGtdAUQ==
-matpower.matpower.commits: 58a69dbdfa8c6620a83d025aaed73c3a6fbe9a4b 2599
+matpower.matpower.commits:
+  offset: 2599
+  total: 2671
 matpower.matpower.forks: Y3Vyc29yOnYyOpHOGETsOA==
 matpower.matpower.issues: Y3Vyc29yOnYyOpK0MjAyNC0wOC0yMVQxNjowODo1N1rOk7nd8w==
 matpower.matpower.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0xMS0wN1QwMToyMDowNVrOJcHakg==
-matpower.most.commits: a5a8d6e6c0e158bdf3e62ac72385bbd15e1768ae 199
-matthieu-str.mescal.commits: a33a4cfbdfbd3496426117a8d295c30be79dc4ac 899
-mesmo-dev.mesmo.commits: ca65710dbf6a0ec160b7421691046c6986248552 1599
-microgridspy.microgridspy.commits: 1838a6c4b2937a2255223098d14621d2d5a951a6 399
-mzy2240.esa.commits: 0c24c608313e316cb80e44c6555e1dca8ee45bca 599
+matpower.most.commits:
+  offset: 199
+  total: 249
+matthieu-str.mescal.commits:
+  offset: 899
+  total: 930
+mesmo-dev.mesmo.commits:
+  offset: 1599
+  total: 1688
+microgridspy.microgridspy.commits:
+  offset: 399
+  total: 445
+mzy2240.esa.commits:
+  offset: 599
+  total: 667
 mzy2240.esa.issues: Y3Vyc29yOnYyOpK0MjAyNS0xMi0xNFQxMToxODo0NlrO3ifySw==
-natlabrockies.h2integrate.commits: af03c23b0712b988892817bbf37d19dcece683fc 2399
+natlabrockies.h2integrate.commits:
+  offset: 2399
+  total: 2479
 natlabrockies.h2integrate.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMy0zMVQwNToxMjoxMFrO-OZ_5Q==
 natlabrockies.h2integrate.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0xOVQxNDo0NjoxOVrO3R3L9w==
-natlabrockies.hopp.commits: 7d1905ea2b1db17600eeb04be02d7a59e365540a 1899
+natlabrockies.hopp.commits:
+  offset: 1899
+  total: 1953
 natlabrockies.hopp.issues: Y3Vyc29yOnYyOpK0MjAyNC0xMC0yMVQxNzoxODo1MVrOmymy7g==
 natlabrockies.hopp.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wMi0xN1QyMToxNzozM1rOi4Lm2g==
-natlabrockies.paraemt_public.commits: d79d735a4a587d56c5b88187d1a499195b6b2b84 99
-natlabrockies.pras.commits: 11d3003e0ff3d343f278cf4f6a1c0d85188593fb 299
-natlabrockies.pysam.commits: 42940894f4ff1d3dbd3db56f72db8adb10a1b09e 599
+natlabrockies.paraemt_public.commits:
+  offset: 99
+  total: 137
+natlabrockies.pras.commits:
+  offset: 299
+  total: 387
+natlabrockies.pysam.commits:
+  offset: 599
+  total: 645
 natlabrockies.pysam.issues: Y3Vyc29yOnYyOpK0MjAyNC0wNC0yNFQyMjoyOTo0MlrOhtfLeQ==
 natlabrockies.pysam.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNy0wOVQxNjoyOToxNVrO79GC8g==
 natlabrockies.pysam.stargazers: Y3Vyc29yOnYyOpK0MjAyNC0wOC0yNlQyMzoxODoxMFrOH2r7UQ==
-natlabrockies.reeds-2.0.commits: 2f583ff5af61b36b0bed43a2deb6a2c1a1104650 99
+natlabrockies.reeds-2.0.commits:
+  offset: 99
+  total: 123
 natlabrockies.reeds-2.0.stargazers: Y3Vyc29yOnYyOpK0MjAyNC0wMi0wM1QyMjoyNzo1MlrOHFevvg==
-natlabrockies.reopt.jl.commits: f952cabdf3e60f6e88eef80bb7bc9e7e24bac643 5999
+natlabrockies.reopt.jl.commits:
+  offset: 5999
+  total: 6010
 natlabrockies.reopt.jl.issues: Y3Vyc29yOnYyOpK0MjAyMy0xMC0wOVQxNzowNTowMVrOcz5_jg==
 natlabrockies.reopt.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0xMi0xOFQxNjowMTo1OVrOuaCRug==
-natlabrockies.rodeo.commits: 6c0abf717c561b33d81388812a21a6a42872d4ff 99
-natlabrockies.sam.commits: 5614c02453e6af56844b39a4aa256cf0e51ed0f0 17199
+natlabrockies.rodeo.commits:
+  offset: 99
+  total: 155
+natlabrockies.sam.commits:
+  offset: 17199
+  total: 17222
 natlabrockies.sam.forks: Y3Vyc29yOnYyOpHOROGRkQ==
 natlabrockies.sam.issues: Y3Vyc29yOnYyOpK0MjAyNS0wMi0xOVQyMjo1NjoyMVrOqr3WIw==
 natlabrockies.sam.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0xMFQyMjoyMjo1OFrO0ZVdVQ==
 natlabrockies.sam.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0wNy0zMFQwNjo1NDoxN1rOJElfnQ==
-niclasmattsson.supergrid.commits: 9e8234feded9003ed3de3a4f6e0035ea088f9099 99
-nlr-distribution-suite.erad.commits: 99b732e3bf32f297056f94bee843ecdc1e7a9703 199
-nreca-bts.omf.commits: 7ea40a1ed40d348f2229fb5373e50c9c7cd877e0 8599
+niclasmattsson.supergrid.commits:
+  offset: 99
+  total: 161
+nlr-distribution-suite.erad.commits:
+  offset: 199
+  total: 229
+nreca-bts.omf.commits:
+  offset: 8599
+  total: 8630
 nreca-bts.omf.issues: Y3Vyc29yOnYyOpK0MjAxNS0wMi0wNFQxNjoxNDoxNVrOA17a6g==
 nreca-bts.omf.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0xMS0yNlQyMToxMTowMVrOtbsTKA==
 nreca-bts.omf.stargazers: Y3Vyc29yOnYyOpK0MjAyMy0wMy0xN1QxNTowODoyMlrOF9pAww==
-oemof.oemof-solph.commits: 24d4e84d6cfd27abb9ddf5ffbe339c2390201465 8299
+oemof.oemof-solph.commits:
+  offset: 8299
+  total: 8367
 oemof.oemof-solph.forks: Y3Vyc29yOnYyOpHOKMGCbg==
 oemof.oemof-solph.issues: Y3Vyc29yOnYyOpK0MjAyNS0wMi0yOFQxNDowOToxNlrOrBf-4A==
 oemof.oemof-solph.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wOS0zMFQwODo0OTozOVrOq0Yngw==
 oemof.oemof-solph.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wNS0yM1QxMzo0ODo0MVrOKZJe2A==
-oemof.oemof-thermal.commits: e0c3c6dc68daca7df7f893c52bb0de2585b60cf4 1199
+oemof.oemof-thermal.commits:
+  offset: 1199
+  total: 1231
 oemof.oemof-thermal.pullRequests: Y3Vyc29yOnYyOpK0MjAyMS0wMi0xMVQxMzoxMTozNFrOIhUW1w==
-onsset.onsset.commits: c154ece124464d8505b50a6aa1a687caeaf9f2d6 799
-opencemorg.opencem.commits: 98b6b37c51a153c1ec43510d5559a420543cd601 299
-openego.edisgo.commits: 755f29dd7fef99e4a57515749777cd2baa04b6b6 4399
+onsset.onsset.commits:
+  offset: 799
+  total: 822
+opencemorg.opencem.commits:
+  offset: 299
+  total: 346
+openego.edisgo.commits:
+  offset: 4399
+  total: 4458
 openego.edisgo.issues: Y3Vyc29yOnYyOpK0MjAyMi0wOS0yMlQxMzo0OToxOVrOUmcWBg==
 openego.edisgo.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0xMi0xMFQxMzowMjoxMVrOuCK97g==
-openego.ego.commits: de5294e9f5041a0fd086ba98e2707988cb711e39 1299
+openego.ego.commits:
+  offset: 1299
+  total: 1311
 openego.ego.pullRequests: Y3Vyc29yOnYyOpK0MjAxOC0xMi0wN1QxMjozMjozMlrODh4Z5g==
-openipsl.openipsl.commits: 8155c73f51ceeec935eb158247c7c043eb697ff5 1899
+openipsl.openipsl.commits:
+  offset: 1899
+  total: 1917
 openipsl.openipsl.issues: Y3Vyc29yOnYyOpK0MjAyMi0wNS0yN1QxNDowNzo0OVrOSo3l-w==
 openipsl.openipsl.pullRequests: Y3Vyc29yOnYyOpK0MjAyMi0xMC0wOVQxOTo0Njo0NVrOQHQZuw==
 openipsl.openipsl.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMi0yNVQxNjoxMDowM1rOJ4W6ag==
-optimal2050.energyrt.commits: a1ee168140f19a484b96e9c69d1111fcc608781c 1399
-osemosys.osemosys.commits: f2801e84c574aa5ab53dd7f262b832f955f21b49 299
+optimal2050.energyrt.commits:
+  offset: 1399
+  total: 1490
+osemosys.osemosys.commits:
+  offset: 299
+  total: 338
 osemosys.osemosys.forks: Y3Vyc29yOnYyOpHONA_wAg==
 osemosys.osemosys.stargazers: Y3Vyc29yOnYyOpK0MjAyMi0wNC0xNFQxMTo0OTo1OFrOE6_a9Q==
-pencleanenergy.match-model.commits: 7886ca7b27d638f27cfbd7dd8c96d4eba9a86cdc 99
-pielube.messpy.commits: 4d9632c66a1bf1c255bac97f0e03a2ff464c42f8 399
-pnnl.exago.commits: d1a4298ca2a88f3e40166d612f641586ec0a49f1 1099
+pencleanenergy.match-model.commits:
+  offset: 99
+  total: 174
+pielube.messpy.commits:
+  offset: 399
+  total: 465
+pnnl.exago.commits:
+  offset: 1099
+  total: 1175
 pnnl.exago.issues: Y3Vyc29yOnYyOpK0MjAyNS0xMi0xN1QyMjowODoyNVrO3vZIpA==
 pnnl.exago.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wMi0xMFQyMTo0NjoxOFrOwtutOw==
-pnnl.tesp.commits: eab66e2a0141312a7a4d4140cb81253898fd622a 2299
+pnnl.tesp.commits:
+  offset: 2299
+  total: 2389
 pnnl.tesp.issues: Y3Vyc29yOnYyOpK0MjAyNC0wNC0xMVQyMzoxMzoxMFrOhXC3DA==
-powergama.powergama.commits: 905690cefb9df88f734efa6209835e3f447a1acb 299
-powergridmodel.power-grid-model.commits: 07a60d63f0a9aba0d5d990fecea76358a091dae6
-  10699
+powergama.powergama.commits:
+  offset: 299
+  total: 345
+powergridmodel.power-grid-model.commits:
+  offset: 10699
+  total: 10714
 powergridmodel.power-grid-model.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMy0yNFQxMDowMzozNFrO9ffQ5A==
 powergridmodel.power-grid-model.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNi0wNVQwNzo0Njo1NlrO4wLVPw==
 powergridmodel.power-grid-model.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMS0yMVQxMToxNTowOVrOJuebpQ==
-powsybl.powsybl-core.commits: 21cfd97057a5ebc6ebfec96aaa3924ffc2dd9a34 3699
+powsybl.powsybl-core.commits:
+  offset: 3699
+  total: 3776
 powsybl.powsybl-core.issues: Y3Vyc29yOnYyOpK0MjAyNi0wNi0xMlQxMzoyNjo0MFrPAAAAARUjMDM=
 powsybl.powsybl-core.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0yOFQxMzowMTo0NlrO1leU6Q==
 powsybl.powsybl-core.stargazers: Y3Vyc29yOnYyOpK0MjAyMy0wNi0xMlQxNjowNTowNFrOGVnw9w==
-powsybl.powsybl-open-loadflow.commits: 803e4c9b209fb1df4d690c6d8f4cddee91aeac47 1099
+powsybl.powsybl-open-loadflow.commits:
+  offset: 1099
+  total: 1138
 powsybl.powsybl-open-loadflow.issues: Y3Vyc29yOnYyOpK0MjAyNC0wNC0wNVQxMjowNDoyMVrOhMqe0Q==
 powsybl.powsybl-open-loadflow.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNy0wM1QwNjo1NTowMFrO7XbRvw==
-powsybl.pypowsybl.commits: 7027b67c829ab1c9cea33b05cd15a424fc0d2149 799
+powsybl.pypowsybl.commits:
+  offset: 799
+  total: 886
 powsybl.pypowsybl.issues: Y3Vyc29yOnYyOpK0MjAyNC0xMS0xM1QwODoyMTo0MlrOnjqRTQ==
 powsybl.pypowsybl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wMy0yNlQxNDo0MzowNlrOzcAJJA==
-prep-next.prep-shot.commits: efd461b1f35ec5fed9141cdf75d87e0443b25d8d 399
+prep-next.prep-shot.commits:
+  offset: 399
+  total: 437
 prep-next.prep-shot.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0xMS0yNFQxMDo1Nzo1MVrOJgHHOQ==
-psrenergy.sddpdso.jl.commits: 84f11838f177bb7ec4975f2aac709ba86ce4c3c4 99
-pypsa.pypsa.commits: 0ff4da8540df55cdc3d3cbad4dc225384252197d 3199
+psrenergy.sddpdso.jl.commits:
+  offset: 99
+  total: 180
+pypsa.pypsa.commits:
+  offset: 3199
+  total: 3278
 pypsa.pypsa.forks: Y3Vyc29yOnYyOpHORYOK6w==
 pypsa.pypsa.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMy0wMlQxOTowMDowNVrO7y5qmw==
 pypsa.pypsa.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0wN1QwODo0NjoyMVrO2RJEUQ==
 pypsa.pypsa.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wNS0yN1QwMjo1NToxMlrOKacCKw==
-quasi-software.resie.commits: ffce29ce45b9f62579e4bc32704f8802e983ed29 1999
-quintel.etengine.commits: 0417a3c2ef57098110656510a6684e3f3893ac84 5799
+quasi-software.resie.commits:
+  offset: 1999
+  total: 2010
+quintel.etengine.commits:
+  offset: 5799
+  total: 5861
 quintel.etengine.issues: Y3Vyc29yOnYyOpK0MjAyNS0xMi0xNVQxMToxMjoxMlrO3lJRKA==
 quintel.etengine.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wMy0yM1QyMDo0OTo0NlrOzM5plQ==
-quintel.etmodel.commits: aae9d0e74b0fa453c0fddfcb5a749a178155f625 10299
+quintel.etmodel.commits:
+  offset: 10299
+  total: 10311
 quintel.etmodel.issues: Y3Vyc29yOnYyOpK0MjAyNS0wMS0yOVQxNDo1NDowOFrOp_4lZw==
 quintel.etmodel.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0yNFQxNTo0MDo0NlrO1WMtfg==
-quintel.pyetm.commits: 3ad8824f6510892857f32b229cad493abcd421c4 299
+quintel.pyetm.commits:
+  offset: 299
+  total: 314
 quintel.pyetm.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0wM1QwODoxMjo1NFrOz8CyIQ==
-rebase-energy.emflow.commits: f949d9b27c30c598594991881907c058bee241ae 99
-reegis.deflex.commits: a081c8a2959985ed7d0fd1ebe14cc11f4e2c7dbd 899
-rheia-framework.rheia.commits: 7eb9711f2d8bb780d53e8d7dc8b1cc1a5ecabae4 99
-richard-weinhold.pomato.commits: 3c2c80f7dbdb91683d7c5d9dbfabc63d49adfa27 399
-rl-institut.multi-vector-simulator.commits: 03bf1fa0a9819aaae275a1cad344d60682a42b2d
-  4999
+rebase-energy.emflow.commits:
+  offset: 99
+  total: 116
+reegis.deflex.commits:
+  offset: 899
+  total: 939
+rheia-framework.rheia.commits:
+  offset: 99
+  total: 197
+richard-weinhold.pomato.commits:
+  offset: 399
+  total: 493
+rl-institut.multi-vector-simulator.commits:
+  offset: 4999
+  total: 5066
 rl-institut.multi-vector-simulator.issues: Y3Vyc29yOnYyOpK0MjAyMS0wMi0wMVQxNjo0OTowN1rOL5iPew==
 rl-institut.multi-vector-simulator.pullRequests: Y3Vyc29yOnYyOpK0MjAyMS0wMy0wNFQxMDowODoyM1rOItlpTw==
-roseautechnologies.roseau_load_flow.commits: c7cac19e5438d445d07c66a114d1d65fa37de601
-  899
+roseautechnologies.roseau_load_flow.commits:
+  offset: 899
+  total: 984
 roseautechnologies.roseau_load_flow.issues: Y3Vyc29yOnYyOpK0MjAyNS0xMi0xMFQwOTowMTowN1rO3WLWpQ==
 roseautechnologies.roseau_load_flow.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wNy0zMVQxNjoyMToyM1rOoZFRPg==
-rwl.pypower.commits: 9c719bb14aa35183e2b77eca43796c5cdd19cdc7 299
+rwl.pypower.commits:
+  offset: 299
+  total: 364
 rwl.pypower.forks: Y3Vyc29yOnYyOpHOLNKZgw==
 rwl.pypower.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMy0yNlQyMjowMzoyNFrOKDGwcg==
-sanpen.veragrid.commits: 577f743080961d70c63af57e25fd8bcce0042c2e 16099
+sanpen.veragrid.commits:
+  offset: 16099
+  total: 16148
 sanpen.veragrid.forks: Y3Vyc29yOnYyOpHOO0w3Wg==
 sanpen.veragrid.issues: Y3Vyc29yOnYyOpK0MjAyNi0wNi0yN1QwOTowMTo1NVrPAAAAARuTxdA=
 sanpen.veragrid.pullRequests: Y3Vyc29yOnYyOpK0MjAyMy0wNS0yNVQxODowMjoyMlrOUV5BQQ==
 sanpen.veragrid.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wMi0wM1QxNDoxNjo1MFrOJyQXmQ==
-sei-international.nemomod.jl.commits: 5b57e4cb1dc0e2f71270b14c360c6ff40cd1f4d0 499
-sienna-platform.powersimulations.jl.commits: b20b2bc90c53d81d2647e31a27a4d03a5e612657
-  10999
+sei-international.nemomod.jl.commits:
+  offset: 499
+  total: 503
+sienna-platform.powersimulations.jl.commits:
+  offset: 10999
+  total: 11067
 sienna-platform.powersimulations.jl.issues: Y3Vyc29yOnYyOpK0MjAyNS0wNy0yN1QwNjo1OTozNVrOwrd1nA==
 sienna-platform.powersimulations.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wMS0wMlQxOTowMjo1N1rOu1H8kQ==
 sienna-platform.powersimulations.jl.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0xMS0yNFQxNDo0MDozOVrOJgJ7mQ==
-sienna-platform.powersimulationsdynamics.jl.commits: 05c8975aa591f2f4622874a4fafdced71165f5c8
-  2399
+sienna-platform.powersimulationsdynamics.jl.commits:
+  offset: 2399
+  total: 2419
 sienna-platform.powersimulationsdynamics.jl.issues: Y3Vyc29yOnYyOpK0MjAyMi0wNy0yN1QxOTo1OToyMFrOTq6Oxg==
 sienna-platform.powersimulationsdynamics.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyMy0wNi0yOFQwMzozNDo1NVrOVBj_3Q==
 sienna-platform.powersimulationsdynamics.jl.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0wOC0xMlQwODoyNzoxM1rOJHo2nA==
-simjunky.leelo.commits: 261d29680d29bc03374f6a50be2823cd51371e38 99
-slacgismo.tess.commits: a42354cd2be4ccd9cf0411cb31c8f0d0f1ae015b 299
+simjunky.leelo.commits:
+  offset: 99
+  total: 123
+slacgismo.tess.commits:
+  offset: 299
+  total: 357
 slacgismo.tess.pullRequests: Y3Vyc29yOnYyOpK0MjAyMS0wNi0xN1QwMTo0MTo1N1rOKA8vEg==
-sogno-platform.dpsim.commits: 4d31d4578c4bf7df0385f080afd7e2006db1563c 4799
+sogno-platform.dpsim.commits:
+  offset: 4799
+  total: 4889
 sogno-platform.dpsim.issues: Y3Vyc29yOnYyOpK0MjAyMy0xMC0yMVQxMTowOToxN1rOdI23HA==
 sogno-platform.dpsim.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNi0wM1QxNDo1Njo0M1rO4kcrcA==
 sogno-platform.dpsim.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0xMi0xMVQxMTo0ODozMFrOJkQcXQ==
-sogno-platform.pymfm.commits: d649b843a68d40d3d7d8225e4b13cd4f750a1b83 99
-sp-etx.friendlysam.commits: b1b2d5e649d10acedc7266577d852aa02aa679f1 299
-spf-ost.optihood.commits: 88e7ca27942a3e65ecaf9f417a312c64649f9757 1199
+sogno-platform.pymfm.commits:
+  offset: 99
+  total: 113
+sp-etx.friendlysam.commits:
+  offset: 299
+  total: 339
+spf-ost.optihood.commits:
+  offset: 1199
+  total: 1206
 spf-ost.optihood.issues: Y3Vyc29yOnYyOpK0MjAyNi0wNC0xNlQwOTowNjowM1rO_sePBw==
-spine-tools.spineopt.jl.commits: 47d6de3c6adffb651ad534f7189fe5fd547a18b3 4199
+spine-tools.spineopt.jl.commits:
+  offset: 4199
+  total: 4222
 spine-tools.spineopt.jl.issues: Y3Vyc29yOnYyOpK0MjAyNC0wOS0zMFQxNToyOTo1OFrOmGjwWA==
 spine-tools.spineopt.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0wNVQwNjo1Mjo0MVrO2Esjow==
-switch-model.switch.commits: 239d62cbe9baeec3bb05e56487241bdea60740af 699
+switch-model.switch.commits:
+  offset: 699
+  total: 799
 switch-model.switch.pullRequests: Y3Vyc29yOnYyOpK0MjAxOS0xMC0wNFQxODowNDo0NlrOE1vpTg==
 switch-model.switch.stargazers: Y3Vyc29yOnYyOpK0MjAyMy0wNS0wN1QwMjowMDo1OFrOGL9NbQ==
 sylvan-energy.gridpath.issues: Y3Vyc29yOnYyOpK0MjAyMi0xMi0xNlQxODo0NDoyN1rOWXLVuA==
 sylvan-energy.gridpath.pullRequests: Y3Vyc29yOnYyOpK0MjAxOS0wOS0xNFQwMDowMToyMlrOEuzmrw==
-temoaproject.temoa.commits: e8bf144bb4be8f881679305c2b2414a57002f3fc 2099
+temoaproject.temoa.commits:
+  offset: 2099
+  total: 2165
 temoaproject.temoa.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNy0xNFQwMTo0Mzo0NFrO8VdVuA==
 temoaproject.temoa.stargazers: Y3Vyc29yOnYyOpK0MjAyNi0wNC0xNVQwNzoyMDoxNFrOKLO1tg==
-thales1330.psp.commits: 5a8fc5cd7032912e7dda19f0de37799b1bd9e9af 499
-transition-zero.tz-osemosys.commits: 8d19e9382ed9c99e25e5697f66c517e1b096ccaf 199
+thales1330.psp.commits:
+  offset: 499
+  total: 572
+transition-zero.tz-osemosys.commits:
+  offset: 199
+  total: 204
 transition-zero.tz-osemosys.pullRequests: Y3Vyc29yOnYyOpK0MjAyNC0wNS0yNFQwOTo0OTozMVrOcHDlLw==
-tulipaenergy.tulipaenergymodel.jl.commits: 88d7accd53e9f0c008454891833564732d0cfdb1
-  699
+tulipaenergy.tulipaenergymodel.jl.commits:
+  offset: 699
+  total: 753
 tulipaenergy.tulipaenergymodel.jl.issues: Y3Vyc29yOnYyOpK0MjAyNi0wMy0xMlQwNzo1Njo1NVrO8irkiA==
 tulipaenergy.tulipaenergymodel.jl.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNS0xMVQxMjo1MDo1MFrO2kEhHw==
-tum-ens.hamlet.commits: 22a03a4097aadb6db680dc8dae9f4c2bf8dc46e0 599
-tum-ens.rivus.commits: b96937e8ff6b66919fd431de2c604d40c7dc1fd6 199
-tum-ens.urbs.commits: e542b3126d11e6d081ce35236a26ef105160e480 799
+tum-ens.hamlet.commits:
+  offset: 599
+  total: 687
+tum-ens.rivus.commits:
+  offset: 199
+  total: 251
+tum-ens.urbs.commits:
+  offset: 799
+  total: 832
 tum-ens.urbs.forks: Y3Vyc29yOnYyOpHOHO3Eig==
 tum-ens.urbs.issues: Y3Vyc29yOnYyOpK0MjAxOS0wNC0wMVQxMTowODo1NFrOGX1XQA==
 tum-ens.urbs.pullRequests: Y3Vyc29yOnYyOpK0MjAxNy0xMi0wOFQxMjowNzoxM1rOCV8ddw==
 tum-ens.urbs.stargazers: Y3Vyc29yOnYyOpK0MjAyNS0xMi0wMVQwOTozMzoyM1rOJh1Yuw==
-tum-ewk.ficus.commits: 25403c97aa14a8466130f17327e11c76f62d5365 99
-tum-ewk.opentumflex.commits: 830b19b5c42f21d47ca64d3b146c9c6064a55b68 399
-unsw-ceem.nempy.commits: 2d3cef0e5545c820067fecddfa2e2fd984ac5583 399
-upb-lea.electricgrid.jl.commits: 3057471a1e55d4626236b98721864f70fcb815d9 1199
-uu-er.adopt-net0.commits: f5a7ef836e318aaa3185002501e905a8e5c318b3 1499
+tum-ewk.ficus.commits:
+  offset: 99
+  total: 160
+tum-ewk.opentumflex.commits:
+  offset: 399
+  total: 451
+unsw-ceem.nempy.commits:
+  offset: 399
+  total: 455
+upb-lea.electricgrid.jl.commits:
+  offset: 1199
+  total: 1277
+uu-er.adopt-net0.commits:
+  offset: 1499
+  total: 1527
 uu-er.adopt-net0.issues: Y3Vyc29yOnYyOpK0MjAyNC0xMC0wN1QwNzowODoyNVrOmSggJQ==
 uu-er.adopt-net0.pullRequests: Y3Vyc29yOnYyOpK0MjAyNS0wNi0xNlQxMTozNDo1OVrOmrMJRg==
-villasframework.node.commits: fd49122d5d8a7291ca25d876ff9491c5495cb83d 6599
+villasframework.node.commits:
+  offset: 6599
+  total: 6648
 villasframework.node.issues: Y3Vyc29yOnYyOpK0MjAyNS0xMS0wNlQwOToxMjozMlrO1kUKVw==
 villasframework.node.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0xM1QxMzo1MjozM1rO0f-8-g==
-vub-hydr.revub.commits: fdf419f9a755e7401fe035acd6b85a3991d470f4 99
-youngfaithful.capacityexpansion.jl.commits: 27dd491ab1e816e69c818b8777c2dc5da77887d8
-  499
-zen-universe.zen-garden.commits: d75cc8ffdb7cc7bb9b15a9c2b8c8a73d1b0d3a2f 3599
+vub-hydr.revub.commits:
+  offset: 99
+  total: 195
+youngfaithful.capacityexpansion.jl.commits:
+  offset: 499
+  total: 543
+zen-universe.zen-garden.commits:
+  offset: 3599
+  total: 3664
 zen-universe.zen-garden.issues: Y3Vyc29yOnYyOpK0MjAyNS0xMi0wOVQxMDowOTo1NFrO3SRx7w==
 zen-universe.zen-garden.pullRequests: Y3Vyc29yOnYyOpK0MjAyNi0wNC0xMFQxNDoyMjo1M1rO0XmKTg==

--- a/user_analysis/github_api.py
+++ b/user_analysis/github_api.py
@@ -287,6 +287,7 @@ class GitHubRepositoryCollectorGH:
                     defaultBranchRef {
                       target {
                         ... on Commit {
+                          oid
                           history(first: 100, after: $cursor) {
                             totalCount
                             pageInfo {
@@ -323,33 +324,27 @@ class GitHubRepositoryCollectorGH:
         else:
             return author_data.get("login", None)
 
+    def _fetch_page(
+        self, query_name: str, owner: str, name: str, cursor: str | None, page: int
+    ) -> dict:
+        """Execute one page of a paginated query."""
+        LOGGER.warning(f"Fetching {query_name} - Page: {page} - Cursor: {cursor}")
+        variables = {"owner": owner, "name": name, "cursor": cursor}
+        return self.client.execute_query(self.queries[query_name], variables)
+
     def _paginate_query(self, query_name: str, repo: str) -> list[dict]:
-        """Execute a query with pagination support."""
+        """Execute a query with pagination support, resuming from the cached cursor."""
         all_data = []
         owner, name = repo.strip("/").split("/")
         cache_key = f"{owner}.{name}.{query_name}"
-        cursor = PAGINATION_CACHE.get(cache_key, None)
+        cached_cursor = cursor = PAGINATION_CACHE.get(cache_key, None)
         page = 1
 
         while True:
-            LOGGER.warning(f"Fetching {query_name} - Page: {page} - Cursor: {cursor}")
-
-            variables = {"owner": owner, "name": name, "cursor": cursor}
-
-            data = self.client.execute_query(self.queries[query_name], variables)
+            data = self._fetch_page(query_name, owner, name, cursor, page)
             if not data:
                 break
-            # Extract the relevant data based on query type
-            if query_name == "commits":
-                # Special handling for commits nested structure
-                default_branch = data["repository"].get("defaultBranchRef")
-                if default_branch is None:
-                    LOGGER.warning(f"No default branch found for {repo}")
-                    break
-                items = default_branch["target"]["history"]
-            else:
-                items = data["repository"][query_name]
-
+            items = data["repository"][query_name]
             if query_name == "stargazers":
                 all_data.extend(items["edges"])
             else:
@@ -357,12 +352,93 @@ class GitHubRepositoryCollectorGH:
 
             if not items["pageInfo"]["hasNextPage"]:
                 break
-            cursor = items["pageInfo"]["endCursor"]
-            PAGINATION_CACHE[cache_key] = cursor
+            cursor = PAGINATION_CACHE[cache_key] = items["pageInfo"]["endCursor"]
             page += 1
-        if page > 1:
+        if cursor != cached_cursor:
             util.dump_yaml("pagination_cache_gh", PAGINATION_CACHE)
         LOGGER.warning(f"Fetched {len(all_data)} {query_name} items")
+        return all_data
+
+    @staticmethod
+    def _commit_cursor_index(cursor: str) -> int:
+        """Get the zero-based item index from a commit history cursor (``<head SHA> <index>``)."""
+        return int(cursor.split(" ")[1])
+
+    def _load_commit_checkpoint(self, cache_key: str) -> dict | None:
+        """Load the cached commit checkpoint, upgrading a legacy full-cursor cache entry."""
+        checkpoint = PAGINATION_CACHE.get(cache_key)
+        if isinstance(checkpoint, str):
+            return {"offset": self._commit_cursor_index(checkpoint), "total": None}
+        return checkpoint
+
+    @staticmethod
+    def _commit_checkpoint_range(checkpoint: dict, total: int) -> tuple[int, int]:
+        """Map a commit checkpoint onto the current history.
+
+        History is newest-first, so commits pushed since the checkpoint was taken shift the
+        already-fetched range further down the history.
+
+        Args:
+            checkpoint (dict): Cached ``offset`` (index of last fetched commit) and ``total``.
+            total (int): Total number of commits in the history now.
+
+        Returns:
+            tuple[int, int]: Number of commits pushed since the checkpoint was taken and the
+                index at which the already-fetched range now ends.
+        """
+        if checkpoint["total"] is None:
+            new_commits = 0
+        else:
+            new_commits = max(total - checkpoint["total"], 0)
+        return new_commits, new_commits + checkpoint["offset"]
+
+    def _paginate_commits(self, repo: str) -> list[dict]:
+        """Execute the commit history query with pagination support.
+
+        Commit cursors are ``<branch head SHA> <item index>`` pairs, which go stale as soon as the branch head moves,
+        so we cache the item index (alongside the total commit count at that point) and rebuild the cursor from the current head SHA.
+        History is newest-first, so each run starts at the head to pick up newly pushed commits before skipping over the range that previous runs already fetched.
+        """
+        all_data = []
+        owner, name = repo.strip("/").split("/")
+        cache_key = f"{owner}.{name}.commits"
+        checkpoint = self._load_commit_checkpoint(cache_key)
+        cached_entry = PAGINATION_CACHE.get(cache_key, None)
+        new_commits, checkpoint_index = 0, -1
+        cursor = None
+        page = 1
+
+        while True:
+            data = self._fetch_page("commits", owner, name, cursor, page)
+            if not data:
+                break
+            default_branch = data["repository"].get("defaultBranchRef")
+            if default_branch is None:
+                LOGGER.warning(f"No default branch found for {repo}")
+                break
+            items = default_branch["target"]["history"]
+            all_data.extend(items["nodes"])
+
+            total = items["totalCount"]
+            if checkpoint is not None and page == 1:
+                new_commits, checkpoint_index = self._commit_checkpoint_range(
+                    checkpoint, total
+                )
+            if not items["pageInfo"]["hasNextPage"]:
+                index = total - 1
+            else:
+                index = self._commit_cursor_index(items["pageInfo"]["endCursor"])
+                if new_commits - 1 <= index < checkpoint_index:
+                    index = checkpoint_index
+            if index >= checkpoint_index:
+                PAGINATION_CACHE[cache_key] = {"total": total, "offset": index}
+            if index >= total - 1:
+                break
+            cursor = f"{default_branch['target']['oid']} {index}"
+            page += 1
+        if PAGINATION_CACHE.get(cache_key, None) != cached_entry:
+            util.dump_yaml("pagination_cache_gh", PAGINATION_CACHE)
+        LOGGER.warning(f"Fetched {len(all_data)} commits items")
         return all_data
 
     def _parse_issue_data(self, issue_data: dict) -> list[dict]:
@@ -520,7 +596,7 @@ class GitHubRepositoryCollectorGH:
         # Fetch commits (optional - can be expensive for large repos)
         # Uncomment the lines below to collect commit statistics
         # Note: This query only fetches commits from the default branch
-        commits_data = self._paginate_query("commits", repo)
+        commits_data = self._paginate_commits(repo)
         for commit_data in commits_data:
             results.append(self._parse_commit_data(commit_data, is_default_branch=True))
 


### PR DESCRIPTION
Fixes #243 

GraphQL commit hashes were actually linked to the latest default branch SHA so were always changing. This fixes that by applying pagination but not presupposing the page hash (which will be collected from the repo at runtime). Our repo interaction data is really bloating but what can you do 🤷 

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- [ ] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Changelog updated
