### PR TITLE
Update stargazer count getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Calendar Versioning](https://calver.org/).
 
 ## 2026-08-31
 
+### Changed
+
+- Stars are now collected from the anonymous GitHub star history endpoint (`/repos/{owner}/{repo}/stargazers/history`).
+  GitHub has restricted the stargazer _listing_ endpoints (REST `/stargazers` and the GraphQL `stargazers` connection) to repository admins and collaborators, and they return silently empty for everyone else, so star counts had stopped updating for almost every tool in the inventory.
+  The replacement endpoint reports star _counts_ per day with no user identity of any kind, so newly collected stars are recorded against a placeholder `anonymous` username and are excluded from the user interaction analysis.
+  Stargazers collected before this change keep their usernames.
+  (#268)
+
 ### Fixed
 
 - GitHub commit history pagination cache, which was storing cursors containing the branch head SHA and so went stale as soon as new commits were pushed (#243).

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: openmod-tracker contributors
+#
+# SPDX-License-Identifier: MIT
+
+
+"""Test suite for collecting anonymous GitHub star history.
+
+Stargazer listings are restricted to repository admins/collaborators, so stars are collected from the
+star history endpoint, which reports per-day counts with no user identity.
+"""
+
+import sys
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+USER_ANALYSIS_DIR = Path(__file__).parent.parent / "user_analysis"
+sys.path.insert(0, str(USER_ANALYSIS_DIR))
+
+import get_repo_interactions  # noqa: E402
+import github_api  # noqa: E402
+
+
+def week_bucket(start: date, days: list[int]) -> dict:
+    """Build one weekly star history bucket, as returned by the API."""
+    return {
+        "week": int(
+            datetime(start.year, start.month, start.day, tzinfo=UTC).timestamp()
+        ),
+        "total": sum(days),
+        "days": days,
+    }
+
+
+@pytest.fixture
+def collector(monkeypatch):
+    """A collector whose REST calls are served from a stubbed, paginated star history."""
+    monkeypatch.setattr(github_api, "STAR_HISTORY_PER_PAGE", 2)
+    collector = github_api.GitHubRepositoryCollectorGH.__new__(
+        github_api.GitHubRepositoryCollectorGH
+    )
+    collector.queries = {}
+    return collector
+
+
+@pytest.fixture
+def stub_history(collector, monkeypatch):
+    """Serve a fixed list of weekly buckets (newest first) through paginated REST responses."""
+
+    def _stub(weeks: list[dict]):
+        calls = []
+
+        def execute_rest_query(path, params=None):
+            calls.append(params["page"])
+            start = (params["page"] - 1) * params["per_page"]
+            return weeks[start : start + params["per_page"]]
+
+        client = type(
+            "Client", (), {"execute_rest_query": staticmethod(execute_rest_query)}
+        )()
+        monkeypatch.setattr(collector, "client", client, raising=False)
+        return calls
+
+    return _stub
+
+
+class TestStarHistoryDays:
+    """Flattening weekly star history buckets into per-day counts."""
+
+    def test_flattens_weeks_to_days(self):
+        """Each day in a week bucket becomes its own dated count."""
+        weeks = [week_bucket(date(2026, 5, 3), [0, 2, 0, 0, 1, 0, 0])]
+        assert github_api.GitHubRepositoryCollectorGH._star_history_days(weeks) == {
+            date(2026, 5, 4): 2,
+            date(2026, 5, 7): 1,
+        }
+
+    def test_drops_days_without_stars(self):
+        """Days nobody starred on are not carried through."""
+        weeks = [week_bucket(date(2026, 5, 3), [0] * 7)]
+        assert github_api.GitHubRepositoryCollectorGH._star_history_days(weeks) == {}
+
+
+class TestLegacyStarCursor:
+    """Resuming from checkpoints left by the previous, named-stargazer collector."""
+
+    @pytest.mark.parametrize(
+        ("cursor", "expected"),
+        [
+            # Legacy GraphQL stargazer cursors, which embed the last collected ``starredAt``.
+            ("Y3Vyc29yOnYyOpK0MjAyNi0wMy0xMlQxNjoyMTo0M1rOJ9tudA==", date(2026, 3, 12)),
+            ("Y3Vyc29yOnYyOpK0MjAxOS0wOC0xOFQyMzozMDowOFrOCuY94Q==", date(2019, 8, 18)),
+            ("bm90LWEtY3Vyc29y", None),  # valid base64, no timestamp
+            ("not base64 !!", None),
+        ],
+    )
+    def test_date_recovery(self, cursor, expected):
+        """The last collected star date is read back out of a legacy cursor, if there is one."""
+        assert (
+            github_api.GitHubRepositoryCollectorGH._legacy_star_cursor_date(cursor)
+            == expected
+        )
+
+    def test_caller_date_takes_precedence_over_cache(self, collector, monkeypatch):
+        """Previously collected interactions are a better checkpoint than a stale cursor."""
+        monkeypatch.setitem(
+            github_api.PAGINATION_CACHE,
+            "owner.name.stargazers",
+            "Y3Vyc29yOnYyOpK0MjAyNi0wMy0xMlQxNjoyMTo0M1rOJ9tudA==",
+        )
+        assert collector._star_checkpoint("owner/name", date(2026, 6, 1)) == date(
+            2026, 6, 1
+        )
+
+    def test_falls_back_to_cached_cursor(self, collector, monkeypatch):
+        """Without collected interactions, the legacy cursor says where the named stargazers stopped."""
+        monkeypatch.setitem(
+            github_api.PAGINATION_CACHE,
+            "owner.name.stargazers",
+            "Y3Vyc29yOnYyOpK0MjAyNi0wMy0xMlQxNjoyMTo0M1rOJ9tudA==",
+        )
+        assert collector._star_checkpoint("owner/name", None) == date(2026, 3, 12)
+
+    def test_no_checkpoint_available(self, collector):
+        """A repository never collected before has no checkpoint."""
+        assert collector._star_checkpoint("unknown/repo", None) is None
+
+
+class TestPaginateStars:
+    """Walking the star history backwards from the most recent week."""
+
+    def test_one_record_per_star_oldest_first(self, collector, stub_history):
+        """Counts are expanded into one record per star, indexed within the day."""
+        stub_history([week_bucket(date(2020, 5, 3), [0, 2, 0, 0, 1, 0, 0])])
+        assert collector._paginate_stars("owner/name") == [
+            {"date": date(2020, 5, 4), "index": 0},
+            {"date": date(2020, 5, 4), "index": 1},
+            {"date": date(2020, 5, 7), "index": 0},
+        ]
+
+    def test_pages_back_to_repository_creation(self, collector, stub_history):
+        """Without a checkpoint, paging continues until the history runs out."""
+        weeks = [
+            week_bucket(date(2020, 5, 24) - timedelta(weeks=i), [1, 0, 0, 0, 0, 0, 0])
+            for i in range(5)
+        ]
+        calls = stub_history(weeks)
+        assert len(collector._paginate_stars("owner/name")) == 5
+        # Three full pages of two, then an empty page marking the end of the history.
+        assert calls == [1, 2, 3, 4]
+
+    def test_stops_at_checkpoint(self, collector, stub_history):
+        """Paging stops on the page that reaches back past the checkpoint."""
+        weeks = [
+            week_bucket(date(2020, 5, 24) - timedelta(weeks=i), [1, 0, 0, 0, 0, 0, 0])
+            for i in range(5)
+        ]
+        calls = stub_history(weeks)
+        stars = collector._paginate_stars("owner/name", date(2020, 5, 10))
+        assert [star["date"] for star in stars] == [
+            date(2020, 5, 17),
+            date(2020, 5, 24),
+        ]
+        # The second page reaches back past the checkpoint, so the remaining pages are not fetched.
+        assert calls == [1, 2]
+
+    def test_excludes_the_checkpoint_day_itself(self, collector, stub_history):
+        """The checkpoint day is already collected, so its stars are not collected again."""
+        stub_history([week_bucket(date(2020, 5, 3), [0, 2, 0, 0, 1, 0, 0])])
+        stars = collector._paginate_stars("owner/name", date(2020, 5, 4))
+        assert [star["date"] for star in stars] == [date(2020, 5, 7)]
+
+    def test_excludes_the_current_day(self, collector, stub_history):
+        """Today is still accumulating stars, so it is left until the next run."""
+        today = datetime.now(UTC).date()
+        week_start = today - timedelta(days=(today.weekday() + 1) % 7)
+        stub_history(
+            [
+                week_bucket(week_start, [1] * 7),
+                week_bucket(week_start - timedelta(weeks=1), [1] * 7),
+            ]
+        )
+        collected = [star["date"] for star in collector._paginate_stars("owner/name")]
+        assert today not in collected
+        assert today - timedelta(days=1) in collected
+
+    def test_handles_failed_request(self, collector, monkeypatch):
+        """A failed request yields no stars rather than raising."""
+        client = type(
+            "Client",
+            (),
+            {"execute_rest_query": staticmethod(lambda path, params=None: None)},
+        )()
+        monkeypatch.setattr(collector, "client", client, raising=False)
+        assert collector._paginate_stars("owner/name") == []
+
+    def test_stops_at_pagination_limit(self, collector, stub_history, monkeypatch):
+        """Paging gives up at the API's page limit rather than looping forever."""
+        monkeypatch.setattr(github_api, "STAR_HISTORY_MAX_PAGES", 2)
+        weeks = [
+            week_bucket(date(2020, 5, 24) - timedelta(weeks=i), [1, 0, 0, 0, 0, 0, 0])
+            for i in range(10)
+        ]
+        calls = stub_history(weeks)
+        assert len(collector._paginate_stars("owner/name")) == 4
+        assert calls == [1, 2]
+
+
+class TestParseStarData:
+    """Turning anonymous star counts into interaction records."""
+
+    def test_anonymous_username_and_day_index(self, collector):
+        """Stars have no user, so they get a placeholder username and their index within the day."""
+        assert collector._parse_star_data({"date": date(2020, 5, 4), "index": 1}) == {
+            "interaction": "stargazer",
+            "username": github_api.ANONYMOUS_USERNAME,
+            "number": 1,
+            "created": date(2020, 5, 4),
+        }
+
+    def test_same_day_stars_survive_deduplication(self, collector):
+        """The day index is what keeps otherwise-identical stars distinct downstream."""
+        stars = [
+            collector._parse_star_data({"date": date(2020, 5, 4), "index": index})
+            for index in range(3)
+        ]
+        assert len(pd.DataFrame(stars).drop_duplicates()) == 3
+
+
+class TestStarsCollectedThrough:
+    """Deriving the star collection checkpoint from previously collected interactions."""
+
+    @pytest.fixture
+    def interactions(self):
+        """Collected interactions spanning two repositories."""
+        return pd.DataFrame(
+            [
+                {
+                    "username": "anonymous",
+                    "interaction": "stargazer",
+                    "created": "2026-01-05",
+                    "repo": "gh:a/b",
+                },
+                {
+                    "username": "anonymous",
+                    "interaction": "stargazer",
+                    "created": "2026-03-11",
+                    "repo": "gh:a/b",
+                },
+                {
+                    "username": "someone",
+                    "interaction": "commit",
+                    "created": "2026-06-01",
+                    "repo": "gh:a/b",
+                },
+                {
+                    "username": "anonymous",
+                    "interaction": "stargazer",
+                    "created": "2026-08-09",
+                    "repo": "gh:c/d",
+                },
+            ]
+        )
+
+    def test_latest_star_for_repo(self, interactions):
+        """The checkpoint is the most recent star collected for the repository."""
+        assert get_repo_interactions.get_latest_date_of_named_stargazers(
+            interactions, "gh:a/b"
+        ) == date(2026, 3, 11)
+
+    def test_ignores_other_repos(self, interactions):
+        """Each repository is checkpointed independently."""
+        assert get_repo_interactions.get_latest_date_of_named_stargazers(
+            interactions, "gh:c/d"
+        ) == date(2026, 8, 9)
+
+    def test_repo_without_stars(self, interactions):
+        """A repository with no collected stars has no checkpoint."""
+        assert (
+            get_repo_interactions.get_latest_date_of_named_stargazers(
+                interactions, "gh:e/f"
+            )
+            is None
+        )
+
+    def test_empty_interactions(self):
+        """Nothing collected yet means no checkpoint."""
+        empty = pd.DataFrame(columns=get_repo_interactions.COLS)
+        assert (
+            get_repo_interactions.get_latest_date_of_named_stargazers(empty, "gh:a/b")
+            is None
+        )

--- a/user_analysis/get_repo_interactions.py
+++ b/user_analysis/get_repo_interactions.py
@@ -11,6 +11,7 @@ pagination, and error handling.
 """
 
 import logging
+from datetime import date
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -32,6 +33,30 @@ COLS = [
     "merged",
     "repo",
 ]
+
+
+def get_latest_date_of_named_stargazers(
+    interactions: pd.DataFrame, host_repo: str
+) -> date | None:
+    """Get the date of the most recent star already collected for a repository.
+
+    GitHub no longer exposes individual stargazers, only per-day star counts.
+    So, previously collected stars cannot be matched against newly fetched ones.
+    The date of the latest collected star is therefore what tells the collector where to resume without double-counting.
+
+    Args:
+        interactions (pd.DataFrame): Previously collected interactions across all repositories.
+        host_repo (str): Host-prefixed repository path, e.g. ``gh:owner/name``.
+
+    Returns:
+        date | None: Date of the latest collected star, or None if none have been collected.
+    """
+    stars = interactions[
+        (interactions["repo"] == host_repo)
+        & (interactions["interaction"] == "stargazer")
+    ]
+    latest = pd.to_datetime(stars["created"], errors="coerce").max()
+    return None if pd.isna(latest) else latest.date()
 
 
 def get_repo_and_host(url: str) -> str | None:
@@ -97,7 +122,10 @@ def cli(stats_file: Path, out_path: Path):
 
         # Route to appropriate collector
         if host == "gh":
-            df = github_collector.collect_repo_data(repo_path)
+            df = github_collector.collect_repo_data(
+                repo_path,
+                get_latest_date_of_named_stargazers(existing_interactions, host_repo),
+            )
         elif host == "gl":
             df = gitlab_collector.collect_repo_data(repo_path)
         else:

--- a/user_analysis/get_user_details.py
+++ b/user_analysis/get_user_details.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import click
 import pandas as pd
-from github_api import GitHubClientGH, get_user_details_gh
+from github_api import ANONYMOUS_USERNAME, GitHubClientGH, get_user_details_gh
 from gitlab_api import GitLabClientGL, get_user_details_gl
 from tqdm import tqdm
 
@@ -71,6 +71,8 @@ def cli(repo_interactions: Path, outdir: Path, refresh_cache: bool):
     gl_client = GitLabClientGL()
 
     users_df = pd.read_csv(repo_interactions)
+    # Stars are only available as anonymous daily counts, so their placeholder username has no details to fetch.
+    users_df = users_df[users_df.username != ANONYMOUS_USERNAME]
 
     # Filter out any users for which we're removed the repo they are interacting with + any orgs that now disappear.
     # This ensures we don't have user/org details for users who no longer interact with any repos in our dataset.

--- a/user_analysis/github_api.py
+++ b/user_analysis/github_api.py
@@ -7,11 +7,14 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import pandas as pd
@@ -25,6 +28,16 @@ load_dotenv()
 LOGGER = logging.getLogger(__name__)
 
 PAGINATION_CACHE = util.read_yaml("pagination_cache_gh", exists=False)
+
+#: REST API version providing the anonymous star history endpoint.
+REST_API_VERSION = "2026-03-10"
+#: Star history is returned in weekly buckets, newest first, capped at 30 weeks per page and 100 pages.
+STAR_HISTORY_PER_PAGE = 30
+STAR_HISTORY_MAX_PAGES = 100
+#: Placeholder for stars collected from the star history endpoint, which reports counts without any user identity.
+ANONYMOUS_USERNAME = "anonymous"
+#: The ``starredAt`` timestamp embedded in a legacy (GraphQL) stargazer pagination cursor.
+LEGACY_STAR_CURSOR_DATE = re.compile(rb"(\d{4}-\d{2}-\d{2})T\d{2}:\d{2}:\d{2}Z")
 
 
 @dataclass
@@ -53,6 +66,7 @@ class GitHubClientGH:
                 Defaults to None.
         """
         self.base_url = "https://api.github.com/graphql"
+        self.rest_url = "https://api.github.com"
 
         self.headers = {"Content-Type": "application/json"}
         token = token or os.environ.get("GITHUB_TOKEN")
@@ -101,6 +115,34 @@ class GitHubClientGH:
                 time.sleep(wait_time)
 
         return data["data"]
+
+    def execute_rest_query(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> Any:
+        """Execute a REST API ``GET`` with error handling.
+
+        Args:
+            path (str): API path relative to the REST root, e.g. ``repos/owner/name/stargazers/history``.
+            params (dict[str, Any] | None, optional): Query string parameters. Defaults to None.
+
+        Returns:
+            Any: The decoded JSON body, or None if the request failed.
+        """
+        response = self.session.get(
+            f"{self.rest_url}/{path.lstrip('/')}",
+            params=params,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": REST_API_VERSION,
+            },
+            timeout=30,
+        )
+        try:
+            response.raise_for_status()
+        except requests.RequestException:
+            LOGGER.error(f"REST request to {path} failed: {response.text}")
+            return None
+        return response.json()
 
     def get_rate_limit_info(self) -> tuple[int, int, int]:
         """Get the current GitHub REST API rate limit status for the core resource.
@@ -231,31 +273,6 @@ class GitHubRepositoryCollectorGH:
                   }
                 }
             """,
-            "stargazers": """
-                query RepositoryStargazers($owner: String!, $name: String!, $cursor: String) {
-                  repository(owner: $owner, name: $name) {
-                    stargazers(first: 100, after: $cursor, orderBy: {field: STARRED_AT, direction: ASC}) {
-                      totalCount
-                      pageInfo {
-                        hasNextPage
-                        endCursor
-                      }
-                      edges {
-                        starredAt
-                        node {
-                          login
-                        }
-                      }
-                    }
-                  }
-                  rateLimit {
-                    limit
-                    cost
-                    remaining
-                    resetAt
-                  }
-                }
-            """,
             "forks": """
                 query RepositoryForks($owner: String!, $name: String!, $cursor: String) {
                   repository(owner: $owner, name: $name) {
@@ -345,10 +362,7 @@ class GitHubRepositoryCollectorGH:
             if not data:
                 break
             items = data["repository"][query_name]
-            if query_name == "stargazers":
-                all_data.extend(items["edges"])
-            else:
-                all_data.extend(items["nodes"])
+            all_data.extend(items["nodes"])
 
             if not items["pageInfo"]["hasNextPage"]:
                 break
@@ -441,6 +455,108 @@ class GitHubRepositoryCollectorGH:
         LOGGER.warning(f"Fetched {len(all_data)} commits items")
         return all_data
 
+    @staticmethod
+    def _legacy_star_cursor_date(cursor: str) -> date | None:
+        """Recover the last collected ``starredAt`` date from a legacy GraphQL stargazer cursor."""
+        try:
+            decoded = base64.b64decode(cursor + "=" * (-len(cursor) % 4))
+        except (binascii.Error, ValueError):
+            return None
+        match = LEGACY_STAR_CURSOR_DATE.search(decoded)
+        return None if match is None else date.fromisoformat(match.group(1).decode())
+
+    def _star_checkpoint(self, repo: str, stop_date: date | None) -> date | None:
+        """Get the date through which stars have already been collected for a repository.
+
+        Args:
+            repo (str): Repository path (``owner/name``).
+            stop_date (date | None):
+                Date of the most recent star already collected, taken from previously collected interactions.
+
+        Returns:
+            date | None:
+                The caller's date if given.
+                Otherwise, the date embedded in a legacy GraphQL stargazer cursor left in the pagination cache by earlier (named stargazer) runs.
+                None if neither is available.
+        """
+        if stop_date is not None:
+            return stop_date
+        owner, name = repo.strip("/").split("/")
+        cached = PAGINATION_CACHE.get(f"{owner}.{name}.stargazers", None)
+        return (
+            self._legacy_star_cursor_date(cached) if isinstance(cached, str) else None
+        )
+
+    @staticmethod
+    def _star_history_days(weeks: list[dict]) -> dict[date, int]:
+        """Flatten weekly star history buckets into per-day star counts, dropping days with no stars."""
+        days = {}
+        for week in weeks:
+            week_start = datetime.fromtimestamp(week["week"], UTC).date()
+            for offset, count in enumerate(week["days"]):
+                if count:
+                    days[week_start + timedelta(days=offset)] = count
+        return days
+
+    def _paginate_stars(self, repo: str, stop_date: date | None = None) -> list[dict]:
+        """Fetch star history with pagination support.
+
+        Named stargazer listings are unavailable as of July 2026.
+        We instead use a separate endpoint which reports *counts* of stars per day.
+        It has no user identity of any kind, so each star becomes one identity-less record.
+
+        Stargazer history is now returned newest-first in weekly buckets.
+        So, pagination walks backwards towards repository creation and stops as soon as it reaches a week already covered by ``stop_date``.
+        Only days that have finished are collected, so that stars added later today are not missed.
+
+        Args:
+            repo (str): Repository path (``owner/name``).
+            stop_date (date | None, optional):
+                Date of the most recent star already collected.
+                Days up to and including this date are skipped.
+                Defaults to None, in which case the full history is collected.
+
+        Returns:
+            list[dict]: One ``{"date": ..., "index": ...}`` record per star, oldest first.
+        """
+        owner, name = repo.strip("/").split("/")
+        checkpoint = self._star_checkpoint(repo, stop_date)
+        # A day is only fully collectable once it is over.
+        through = datetime.now(UTC).date() - timedelta(days=1)
+        days: dict[date, int] = {}
+
+        for page in range(1, STAR_HISTORY_MAX_PAGES + 1):
+            LOGGER.warning(f"Fetching stargazers - Page: {page}")
+            weeks = self.client.execute_rest_query(
+                f"repos/{owner}/{name}/stargazers/history",
+                {"per_page": STAR_HISTORY_PER_PAGE, "page": page},
+            )
+            if not weeks:
+                break
+            days.update(
+                {
+                    day: count
+                    for day, count in self._star_history_days(weeks).items()
+                    if day <= through and (checkpoint is None or day > checkpoint)
+                }
+            )
+            # Buckets are newest-first, so the final one bounds how far back this page reaches.
+            oldest_day = datetime.fromtimestamp(weeks[-1]["week"], UTC).date()
+            if checkpoint is not None and oldest_day <= checkpoint:
+                break
+        else:
+            LOGGER.warning(
+                f"Star history for {repo} reached the {STAR_HISTORY_MAX_PAGES} page pagination limit"
+            )
+
+        all_data = [
+            {"date": day, "index": index}
+            for day, count in sorted(days.items())
+            for index in range(count)
+        ]
+        LOGGER.warning(f"Fetched {len(all_data)} stargazers items")
+        return all_data
+
     def _parse_issue_data(self, issue_data: dict) -> list[dict]:
         """Parse issues to get created/closed timestamps and the usernames associated with the author, comments, and reactions."""
         results = []
@@ -529,10 +645,17 @@ class GitHubRepositoryCollectorGH:
         return results
 
     def _parse_star_data(self, star_data: dict) -> dict:
+        """Parse a single star from the anonymous star history.
+
+        Stars carry no user identity, so each gets a placeholder username and its index within the day,
+        which keeps otherwise-identical stars from the same day distinguishable when interactions are
+        de-duplicated downstream.
+        """
         return {
             "interaction": "stargazer",
-            "username": self._parse_author(star_data.get("node")),
-            "created": star_data["starredAt"],
+            "username": ANONYMOUS_USERNAME,
+            "number": star_data["index"],
+            "created": star_data["date"],
         }
 
     def _parse_fork_data(self, fork_data: dict) -> dict:
@@ -567,8 +690,19 @@ class GitHubRepositoryCollectorGH:
             "created": commit_data["committedDate"],
         }
 
-    def collect_repo_data(self, repo: str) -> pd.DataFrame:
-        """Analyze a GitHub repository and return comprehensive activity data."""
+    def collect_repo_data(
+        self, repo: str, latest_date_of_named_stargazers: date | None = None
+    ) -> pd.DataFrame:
+        """Analyze a GitHub repository and return comprehensive activity data.
+
+        Args:
+            repo (str): Repository path (``owner/name``).
+            latest_date_of_named_stargazers (date | None, optional):
+                Date of the most recent star already collected for this repository.
+                Stars are fetched from an endpoint that reports daily counts rather than individual events,
+                so this is needed to avoid re-collecting (and thereby double-counting) days already covered.
+                Defaults to None, in which case the full star history is collected.
+        """
         LOGGER.warning(f"Starting analysis of {repo}")
 
         results = []
@@ -584,7 +718,7 @@ class GitHubRepositoryCollectorGH:
             results.extend(self._parse_pr_data(pr_data))
 
         # Fetch stargazers
-        stars_data = self._paginate_query("stargazers", repo)
+        stars_data = self._paginate_stars(repo, latest_date_of_named_stargazers)
         for star_data in stars_data:
             results.append(self._parse_star_data(star_data))
 


### PR DESCRIPTION
Closes #268 

Gets what we can for stargazer count in lieu of the main API disappearing. Now it is anonymous daily counts. We can still use this. It isn't the end of the world.

Adds yet more bloat to our repository interaction processing...

> [!CAUTION]
> To be merged in after #274 as it builds on top of it. 

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license and the data generated under the repository's CC-BY-4.0 license.
- [ ] I have added myself to the list of contributors in `AUTHORS.md` (if applicable).

## Reviewer checklist

- [ ] Test(s) added to cover contribution
- [ ] Changelog updated
